### PR TITLE
fix: Update README Claude Desktop Configuration to use NPX

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ Add to your `claude_desktop_config.json`:
 {
   "mcpServers": {
     "betterstack-logs": {
-      "command": "node",
-      "args": ["path/to/betterstack-logs-mcp/dist/index.js"],
+      "command": "npx",
+      "args": ["@blaze-money/betterstack-logs-mcp"],
       "env": {
         "BETTERSTACK_CLICKHOUSE_USERNAME": "your_clickhouse_username",
         "BETTERSTACK_CLICKHOUSE_PASSWORD": "your_clickhouse_password",
-        "BETTERSTACK_CLICKHOUSE_QUERY_ENDPOINT": "your_clickhouse_endpoint_url",
+        "BETTERSTACK_CLICKHOUSE_ENDPOINT": "your_clickhouse_endpoint_url",
         "BETTERSTACK_API_TOKEN": "your_api_token_here",
         "BETTERSTACK_DEFAULT_SOURCE_GROUP": "production"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blaze-money/betterstack-logs-mcp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "MCP server for querying and analyzing Betterstack logs via npx",
   "license": "MIT",
   "author": "Blaze",


### PR DESCRIPTION
- Changed command from 'node' to 'npx'
- Updated args to use '@blaze-money/betterstack-logs-mcp' package
- Fixed environment variable name (QUERY_ENDPOINT -> ENDPOINT)
- Now matches the NPX-first approach implemented in the package

This ensures users follow the correct setup instructions using NPX instead of requiring local installation and path configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the README configuration to use NPX and the correct package name, making setup easier and matching the latest package usage. Also fixed the environment variable name for endpoint configuration.

<!-- End of auto-generated description by cubic. -->

