### PR TITLE
fix: Correct ClickHouse endpoint environment variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this to your Claude Code MCP configuration file:
         "BETTERSTACK_API_TOKEN": "your-api-token-here",
         "BETTERSTACK_CLICKHOUSE_USERNAME": "your-clickhouse-username",
         "BETTERSTACK_CLICKHOUSE_PASSWORD": "your-clickhouse-password",
-        "BETTERSTACK_CLICKHOUSE_ENDPOINT": "your-clickhouse-endpoint"
+        "BETTERSTACK_CLICKHOUSE_QUERY_ENDPOINT": "your-clickhouse-endpoint"
       }
     }
   }
@@ -98,7 +98,7 @@ Add to your `claude_desktop_config.json`:
       "env": {
         "BETTERSTACK_CLICKHOUSE_USERNAME": "your_clickhouse_username",
         "BETTERSTACK_CLICKHOUSE_PASSWORD": "your_clickhouse_password",
-        "BETTERSTACK_CLICKHOUSE_ENDPOINT": "your_clickhouse_endpoint_url",
+        "BETTERSTACK_CLICKHOUSE_QUERY_ENDPOINT": "your_clickhouse_endpoint_url",
         "BETTERSTACK_API_TOKEN": "your_api_token_here",
         "BETTERSTACK_DEFAULT_SOURCE_GROUP": "production"
       }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your Claude Code MCP configuration file:
   "mcpServers": {
     "betterstack-logs": {
       "command": "npx",
-      "args": ["@blaze-money/betterstack-logs-mcp"],
+      "args": ["-y", "@blaze-money/betterstack-logs-mcp"],
       "env": {
         "BETTERSTACK_API_TOKEN": "your-api-token-here",
         "BETTERSTACK_CLICKHOUSE_USERNAME": "your-clickhouse-username",
@@ -94,7 +94,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "betterstack-logs": {
       "command": "npx",
-      "args": ["@blaze-money/betterstack-logs-mcp"],
+      "args": ["-y", "@blaze-money/betterstack-logs-mcp"],
       "env": {
         "BETTERSTACK_CLICKHOUSE_USERNAME": "your_clickhouse_username",
         "BETTERSTACK_CLICKHOUSE_PASSWORD": "your_clickhouse_password",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this to your Claude Code MCP configuration file:
 ```json
 {
   "mcpServers": {
-    "betterstack-logs": {
+    "betterstack": {
       "command": "npx",
       "args": ["-y", "@blaze-money/betterstack-logs-mcp"],
       "env": {
@@ -92,7 +92,7 @@ Add to your `claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
-    "betterstack-logs": {
+    "betterstack": {
       "command": "npx",
       "args": ["-y", "@blaze-money/betterstack-logs-mcp"],
       "env": {

--- a/claude-config-example.json
+++ b/claude-config-example.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "betterstack-logs": {
+    "betterstack": {
       "command": "npx",
       "args": ["-y", "@blaze-money/betterstack-logs-mcp"],
       "env": {

--- a/claude-config-example.json
+++ b/claude-config-example.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "betterstack-logs": {
       "command": "npx",
-      "args": ["@blaze-money/betterstack-logs-mcp"],
+      "args": ["-y", "@blaze-money/betterstack-logs-mcp"],
       "env": {
         "BETTERSTACK_API_TOKEN": "your-api-token-here",
         "BETTERSTACK_CLICKHOUSE_USERNAME": "your-clickhouse-username",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blaze-money/betterstack-logs-mcp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "MCP server for querying and analyzing Betterstack logs via npx",
   "license": "MIT",
   "author": "Blaze",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blaze-money/betterstack-logs-mcp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "MCP server for querying and analyzing Betterstack logs via npx",
   "license": "MIT",
   "author": "Blaze",

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ Environment Variables (Required):
 Claude Code MCP Configuration Example:
   {
     "mcpServers": {
-      "betterstack-logs": {
+      "betterstack": {
         "command": "npx",
         "args": ["-y", "@blaze-money/betterstack-logs-mcp"],
         "env": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ Claude Code MCP Configuration Example:
     "mcpServers": {
       "betterstack-logs": {
         "command": "npx",
-        "args": ["@blaze-money/betterstack-logs-mcp"],
+        "args": ["-y", "@blaze-money/betterstack-logs-mcp"],
         "env": {
           "BETTERSTACK_API_TOKEN": "your-token-here",
           "BETTERSTACK_CLICKHOUSE_USERNAME": "your-username",


### PR DESCRIPTION
## Summary
- Fix inconsistent environment variable names in README configuration examples
- Use `BETTERSTACK_CLICKHOUSE_QUERY_ENDPOINT` consistently throughout all examples

## Changes
- Updated NPX configuration example to use correct environment variable name
- Updated Claude Desktop configuration example to use correct environment variable name

🤖 Generated with [Claude Code](https://claude.ai/code)