### PR TITLE
chore: Bump version to 1.0.7 for README configuration fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blaze-money/betterstack-logs-mcp",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blaze-money/betterstack-logs-mcp",
-      "version": "1.0.3",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blaze-money/betterstack-logs-mcp",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "MCP server for querying and analyzing Betterstack logs via npx",
   "license": "MIT",
   "author": "Blaze",


### PR DESCRIPTION
## Summary
- Bump package version to 1.0.7 
- Includes README configuration fixes for ClickHouse endpoint variable names

## Changes
- Version bump from 1.0.6 to 1.0.7
- Package has been successfully published to npm

🤖 Generated with [Claude Code](https://claude.ai/code)