### PR TITLE
fix: get_source_info by name and debug_table_info with source groups

### DIFF
--- a/tests/integration/tools/debug-table-info-integration.test.ts
+++ b/tests/integration/tools/debug-table-info-integration.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { BetterstackClient } from '../../../src/betterstack-client.js'
+import { McpTestHelper } from '../../helpers/mcp-test-helper.js'
+import { createTestServer } from '../../helpers/test-server-factory.js'
+
+describe('Debug Table Info Integration Tests', () => {
+  let server: McpServer
+  let client: BetterstackClient
+  let mcpHelper: McpTestHelper
+
+  beforeEach(() => {
+    const testServer = createTestServer()
+    server = testServer.server
+    client = testServer.client
+    mcpHelper = new McpTestHelper(server)
+  })
+
+  describe('debug_table_info tool via MCP protocol', () => {
+    it('should return table info for a single source', async () => {
+      const result = await mcpHelper.callTool('debug_table_info', {
+        sources: ['Spark - staging | deprecated']
+      })
+
+      expect(result.content[0].type).toBe('text')
+      const text = result.content[0].text
+      expect(text).toContain('**Source: Spark - staging | deprecated**')
+      expect(text).toContain('Resolved Sources (1)')
+    })
+
+    it('should return table info for a source group', async () => {
+      const result = await mcpHelper.callTool('debug_table_info', {
+        source_group: 'Development Environment'
+      })
+
+      expect(result.content[0].type).toBe('text')
+      const text = result.content[0].text
+      expect(text).toContain('Debug Information')
+      expect(text).not.toContain('Debug failed')
+    })
+
+    it('should handle source group with multiple sources without failing', async () => {
+      const result = await mcpHelper.callTool('debug_table_info', {
+        source_group: 'Development Environment'
+      })
+
+      expect(result.content[0].type).toBe('text')
+      const text = result.content[0].text
+      // Should contain info for multiple sources in the group
+      expect(text).toContain('**Source: Spark - staging | deprecated**')
+      expect(text).toContain('**Source: Frontend Application**')
+      expect(text).toContain('**Source: Database Service**')
+    })
+  })
+})

--- a/tests/integration/tools/get-source-info-integration.test.ts
+++ b/tests/integration/tools/get-source-info-integration.test.ts
@@ -30,6 +30,17 @@ describe('Get Source Info Integration Tests', () => {
       expect(text).toContain('Updated: 1/15/2024')
     })
 
+    it('should return source information when looking up by name via MCP protocol', async () => {
+      const result = await mcpHelper.callTool('get_source_info', { source_id: 'Production API Server' })
+
+      expect(result.content[0].type).toBe('text')
+      const text = result.content[0].text
+      expect(text).toContain('**Source: Production API Server**')
+      expect(text).toContain('ID: 1021716')
+      expect(text).toContain('Platform: linux')
+      expect(text).toContain('Retention: 30 days')
+    })
+
     it('should handle non-existent source ID via MCP protocol', async () => {
       const result = await mcpHelper.callTool('get_source_info', { source_id: 'nonexistent' })
 

--- a/tests/unit/tools/get-source-info.test.ts
+++ b/tests/unit/tools/get-source-info.test.ts
@@ -25,12 +25,19 @@ describe('Get Source Info Tool', () => {
     })
 
     it('should return source info when searching by name', async () => {
-      const sources = await client.listSources()
-      const targetSource = sources.find(s => s.name === "Production API Server")
-      
-      expect(targetSource).toBeTruthy()
-      expect(targetSource?.platform).toBe("linux")
-      expect(targetSource?.retention_days).toBe(30)
+      const sourceInfo = await client.getSourceInfo("Production API Server")
+
+      expect(sourceInfo).toBeTruthy()
+      expect(sourceInfo?.id).toBe("1021716")
+      expect(sourceInfo?.platform).toBe("linux")
+      expect(sourceInfo?.retention_days).toBe(30)
+    })
+
+    it('should prefer ID match over name match', async () => {
+      const sourceInfo = await client.getSourceInfo("1021715")
+
+      expect(sourceInfo).toBeTruthy()
+      expect(sourceInfo?.name).toBe("Spark - staging | deprecated")
     })
   })
 })


### PR DESCRIPTION
## Summary
Fixes #17

- **`get_source_info` by name**: Added name matching to `getSourceInfo()` so lookups like `get_source_info({ source_id: "Spark - Production" })` now work alongside ID lookups
- **`debug_table_info` with source groups**: Made `getSourcesWithSchema()` resilient to per-source DESCRIBE failures — if one source's schema fetch fails, it continues with remaining sources instead of failing the entire operation (same pattern as PR #16's multi-source fix)

## Test plan
- [x] Unit test: `get_source_info` resolves by name
- [x] Unit test: `get_source_info` prefers ID match over name
- [x] Integration test: `get_source_info` name lookup via MCP protocol
- [x] Integration test: `debug_table_info` with single source
- [x] Integration test: `debug_table_info` with source group (multiple sources)
- [x] Full test suite passes (239/239 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)